### PR TITLE
allow local instead of global hexo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "hexo": {
     "version": "3.7.1"
   },
+  "scripts" : {
+    "start" : "hexo serve"
+  },
   "dependencies": {
     "hexo": "^3.7.1",
     "hexo-generator-archive": "^0.1.5",


### PR DESCRIPTION
adding a script helper in the npm package.json lets us run the locally installed dependency rather than requiring the developer to install it globally. Also handy for different versions across different projects